### PR TITLE
[WIP] RTK Query導入

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -7,3 +7,4 @@ export {
   useAppDispatch as useDispatch,
   useAppSelector as useSelector,
 } from './redux/hooks';
+export { useGetIndicesQuery } from './redux/services/word';

--- a/packages/shared/src/redux/services/word.ts
+++ b/packages/shared/src/redux/services/word.ts
@@ -1,10 +1,21 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { Index } from '../../types';
 
+// mswが有効化される前にクエリーが飛んじゃう謎の挙動があったので
+// デフォルトのfetchをPromiseでラップしてみたら期待通りに動いた。
+// いまいちわからん。
+const fetchFn: (
+  input: RequestInfo,
+  init?: RequestInit | undefined
+) => Promise<Response> = async (input, init) => {
+  return await fetch(input, init);
+};
+
 export const wordApi = createApi({
   reducerPath: 'wordApi',
   baseQuery: fetchBaseQuery({
     baseUrl: '/',
+    fetchFn: fetchFn,
   }),
   endpoints: (builder) => ({
     getIndices: builder.query<[Index], void>({

--- a/packages/shared/src/redux/services/word.ts
+++ b/packages/shared/src/redux/services/word.ts
@@ -1,0 +1,17 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { Index } from '../../types';
+
+export const wordApi = createApi({
+  reducerPath: 'wordApi',
+  baseQuery: fetchBaseQuery({
+    baseUrl: '/',
+  }),
+  endpoints: (builder) => ({
+    getIndices: builder.query<[Index], void>({
+      query: () => 'question',
+    }),
+  }),
+});
+
+// using TS 4.0
+export const useGetIndicesQuery = wordApi.endpoints.getIndices.useQuery;

--- a/packages/shared/src/redux/store.ts
+++ b/packages/shared/src/redux/store.ts
@@ -1,10 +1,14 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { questionReducer } from './features/question';
+import { wordApi } from './services/word';
 
 export const store = configureStore({
   reducer: {
     questions: questionReducer,
+    [wordApi.reducerPath]: wordApi.reducer,
   },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(wordApi.middleware),
 });
 
 export type RootState = ReturnType<typeof store.getState>;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,0 +1,9 @@
+export type Index = {
+  index_id: number;
+  index: string;
+  questioner: string;
+  frequently_used_count: number;
+  answer_count: number;
+  best_answer: string;
+  date: string;
+};

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -1,12 +1,19 @@
 import Link from 'next/link';
 import Layout from '../components/Layout';
-import { greet, useDispatch, useSelector, dummy } from '@what-is-grass/shared';
+import {
+  greet,
+  useDispatch,
+  useSelector,
+  dummy,
+  useGetIndicesQuery,
+} from '@what-is-grass/shared';
 import { useState, useEffect } from 'react';
 
 const IndexPage: React.FC = () => {
   const [user, setUser] = useState('World');
-  const indices = useSelector((state) => state.questions.indices);
+  const { data: indices, isLoading } = useGetIndicesQuery();
 
+  const dummyIndices = useSelector((state) => state.questions.indices);
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -26,17 +33,18 @@ const IndexPage: React.FC = () => {
         <Link href="/about">
           <a>About</a>
         </Link>
-        <br />
-        <button
-          type="button"
-          onClick={() => {
-            dispatch(dummy());
-          }}
-        >
-          dispatch questions/dummy
-        </button>
-        <pre>{JSON.stringify(indices, null, 2)}</pre>
       </p>
+      <br />
+      <button
+        type="button"
+        onClick={() => {
+          dispatch(dummy());
+        }}
+      >
+        dispatch questions/dummy
+      </button>
+      <pre>{JSON.stringify(dummyIndices, null, 2)}</pre>
+      {isLoading ? 'loading...' : <pre>{JSON.stringify(indices, null, 2)}</pre>}
     </Layout>
   );
 };


### PR DESCRIPTION
RTK Queryを導入したのだけど
- useQueryの中でuseLayoutEffectを使ってるので、nextがサーバー側でビルドする時に警告が毎回でて鬱陶しい([react-reduxのこれ](https://github.com/reduxjs/react-redux/blob/8605088606403f6909597405c67db91d907db86e/src/components/connectAdvanced.js#L35-L41)みたいなことはしてくれてない)
- useQueryを使うとなぜかService Workerでmswが有効化される前にリクエストが飛んでしまって404が返ってくる(useLazyQueryにしてuseEffectの中でtriggerを呼ぶとかしてもmswより先にリクエスト飛ぶのでよくわからん)

などに気がついてしまってプログラマーやめようかしら。