### PR TITLE
Add 回答一覧画面から回答投稿画面へ遷移

### DIFF
--- a/packages/web/pages/answers/[id].tsx
+++ b/packages/web/pages/answers/[id].tsx
@@ -1,6 +1,6 @@
 import AnswerList from '../../components/AnswerList';
 import { useLazyGetAnswersQuery } from '@what-is-grass/shared';
-import { useRouter } from 'next/router';
+import router, { useRouter } from 'next/router';
 import { useEffect } from 'react';
 
 const QuestionAnswer: React.FC = () => {
@@ -15,10 +15,18 @@ const QuestionAnswer: React.FC = () => {
     }
   }, [isReady]);
 
+  const handleNewAnswerClick = () => {
+    router.push(`/new-answer/${indexId}`);
+  };
+
   return (
     <div>
       <h1>ここは質問回答覧</h1>
-      <button>回答</button>
+      {indexId && (
+        <button type="button" onClick={handleNewAnswerClick}>
+          この見出しに回答する
+        </button>
+      )}
       <div>{data && <AnswerList answers={data} />}</div>
       {isLoading ? 'ロード中...' : null}
     </div>


### PR DESCRIPTION
回答一覧画面から回答投稿画面に遷移できるようにした。

### 補足
回答投稿画面を表示したときに回答する見出しを表示してあげないと分かりにくいと思うのだけど後で以下の問題があって考えるの大変なので後で対応する。
- 回答待ち単語一覧画面、質問回答閲覧画面のどちらから遷移してくるかわからない。IndexのデータがどこのAPIコールとしてキャッシュされてるかわからないのでRTK Queryのキャッシュから取りようがない。
- 回答待ち単語一覧画面と質問回答閲覧画面にアクセスした段階でreduxストアに見出し文字列を保存しとく方法もあるけど、そもそも直接URLを打ち込んでアクセスされるとindex_idしかわからないのでバックエンドに問い合わせ必須
- 現状index_idで見出しを取得する機能がAPIに実装されてない。