### PR TITLE
[Refactor] 回答投稿ページをreact-hook-form化

### DIFF
--- a/packages/shared/src/types/answer.ts
+++ b/packages/shared/src/types/answer.ts
@@ -15,7 +15,7 @@ export type NewAnswerRequest = {
   definition: Answer['definition'];
   origin?: Answer['origin'];
   note?: Answer['note'];
-  example?: Pick<Example, 'example_sentence'>[];
+  example?: Example['example_sentence'][];
 };
 export type NewAnswerResponse = Answer;
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -14,6 +14,7 @@
     "next-transpile-modules": "^7.2.0",
     "react": "16.13.1",
     "react-dom": "16.13.1",
+    "react-hook-form": "^6.15.0",
     "react-redux": "^7.2.4"
   },
   "devDependencies": {

--- a/packages/web/pages/new-answer/[id].tsx
+++ b/packages/web/pages/new-answer/[id].tsx
@@ -52,10 +52,11 @@ const NewAnswerPage: React.FC = () => {
     watch('example').filter((e) => e.sentence === '').length !== 0;
 
   const onSubmit: SubmitHandler<FormValues> = (data) => {
+    const example = data.example.filter((e) => e.sentence !== '');
     const newAnswer = {
       index_id: +id,
       ...data,
-      example: data.example.map((e) => e.sentence),
+      example: example.map((e) => e.sentence),
     };
     addAnswer(newAnswer);
   };

--- a/packages/web/pages/new-answer/[id].tsx
+++ b/packages/web/pages/new-answer/[id].tsx
@@ -1,20 +1,13 @@
 import Layout from '../../components/Layout';
 import { useRouter } from 'next/router';
-import React, { useState } from 'react';
+import React from 'react';
+import { useForm, SubmitHandler } from 'react-hook-form';
 import { useAddAnswerMutation } from '@what-is-grass/shared';
 
-const useFormValue: <T>(updater: (e: React.ChangeEvent<T>) => string) => {
-  value: string;
-  onChange: (e: React.ChangeEvent<T>) => void;
-} = (updater) => {
-  const [value, setValue] = useState('');
-
-  return {
-    value,
-    onChange: (e) => {
-      setValue(updater(e));
-    },
-  };
+type FormValues = {
+  definition: string;
+  origin: string;
+  note: string;
 };
 
 const NewAnswerPage: React.FC = () => {
@@ -22,38 +15,37 @@ const NewAnswerPage: React.FC = () => {
   const { id } = router.query;
   const [addAnswer, { isLoading }] = useAddAnswerMutation();
 
-  const textAreaUpdater = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    return e.target.value;
-  };
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>();
 
-  const definition = useFormValue<HTMLTextAreaElement>(textAreaUpdater);
-
-  const origin = useFormValue<HTMLTextAreaElement>(textAreaUpdater);
-
-  const note = useFormValue<HTMLTextAreaElement>(textAreaUpdater);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-
+  const onSubmit: SubmitHandler<FormValues> = ({
+    definition,
+    origin,
+    note,
+  }) => {
     addAnswer({
       index_id: +id,
-      definition: definition.value,
-      origin: origin.value,
-      note: note.value,
+      definition: definition,
+      origin: origin,
+      note: note,
     });
   };
 
   return (
     <Layout title="New Answer">
       <h1>回答してあげよう</h1>
-      <form onSubmit={handleSubmit}>
+      <form onSubmit={handleSubmit(onSubmit)}>
         <label>
           意味:
-          <textarea {...definition} />
+          <textarea name="definition" ref={register({ required: true })} />
+          {errors.definition && <span>意味だけは答えてちょうだいな</span>}
         </label>
         <br />
         <label>
-          由来: <textarea {...origin} />
+          由来: <textarea name="origin" ref={register()} />
         </label>
         <br />
         <label>
@@ -61,10 +53,10 @@ const NewAnswerPage: React.FC = () => {
         </label>
         <br />
         <label>
-          備考: <textarea {...note} />
+          備考: <textarea name="note" ref={register()} />
         </label>
         <br />
-        <input type="submit" value="回答" disabled={isLoading} />
+        <input type="submit" disabled={isLoading} />
         {isLoading ? '送信中...' : null}
       </form>
     </Layout>

--- a/packages/web/pages/new-answer/[id].tsx
+++ b/packages/web/pages/new-answer/[id].tsx
@@ -30,6 +30,14 @@ const NewAnswerPage: React.FC = () => {
     control: control,
   });
 
+  const onRemoveExample = (index: number) => {
+    if (fields.length > 1) {
+      remove(index);
+    }
+  };
+
+  const disableRemove = fields.length === 1;
+
   const onSubmit: SubmitHandler<FormValues> = (data) => {
     const newAnswer = {
       index_id: +id,
@@ -62,7 +70,11 @@ const NewAnswerPage: React.FC = () => {
               ref={register()}
               defaultValue={example.sentence}
             />
-            <button type="button" onClick={() => remove(index)}>
+            <button
+              type="button"
+              onClick={() => onRemoveExample(index)}
+              disabled={disableRemove}
+            >
               この例文を削除
             </button>
             <br />

--- a/packages/web/pages/new-answer/[id].tsx
+++ b/packages/web/pages/new-answer/[id].tsx
@@ -20,6 +20,8 @@ const NewAnswerPage: React.FC = () => {
     register,
     handleSubmit,
     control,
+    getValues,
+    watch,
     formState: { errors },
   } = useForm<FormValues>({
     defaultValues: { example: [{ sentence: '' }] },
@@ -30,6 +32,15 @@ const NewAnswerPage: React.FC = () => {
     control: control,
   });
 
+  const onAppendExample = (defaultValue: { example?: string }) => {
+    const { example } = getValues();
+    const emptyFields = example.filter((e) => e.sentence === '');
+
+    if (emptyFields.length === 0) {
+      append(defaultValue);
+    }
+  };
+
   const onRemoveExample = (index: number) => {
     if (fields.length > 1) {
       remove(index);
@@ -37,6 +48,8 @@ const NewAnswerPage: React.FC = () => {
   };
 
   const disableRemove = fields.length === 1;
+  const disableAppend =
+    watch('example').filter((e) => e.sentence === '').length !== 0;
 
   const onSubmit: SubmitHandler<FormValues> = (data) => {
     const newAnswer = {
@@ -80,7 +93,11 @@ const NewAnswerPage: React.FC = () => {
             <br />
           </label>
         ))}
-        <button type="button" onClick={() => append({})}>
+        <button
+          type="button"
+          onClick={() => onAppendExample({})}
+          disabled={disableAppend}
+        >
           もっと例文を追加
         </button>
         <br />

--- a/yarn.lock
+++ b/yarn.lock
@@ -9182,6 +9182,11 @@ react-error-overlay@^6.0.9:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
   integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
+react-hook-form@^6.15.0:
+  version "6.15.8"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.15.8.tgz#725c139d308c431c4611e4b9d85a49f01cfc0e7a"
+  integrity sha512-prq82ofMbnRyj5wqDe8hsTRcdR25jQ+B8KtCS7BLCzjFHAwNuCjRwzPuP4eYLsEBjEIeYd6try+pdLdw0kPkpg==
+
 react-is@16.13.1, react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
- 回答投稿ページにフォームをreact-hook-formで書き直した。
- 最低限のバリデーションを追加した。
- 例文を配列で送れるようにした。
