### PR TITLE
[Add] 使いまわせるフォームのコンポーネント

### DIFF
--- a/packages/web/components/Button.tsx
+++ b/packages/web/components/Button.tsx
@@ -1,0 +1,50 @@
+import classNames from 'classnames';
+import { FC } from 'react';
+
+type ButtonColorSchemeOptions =
+  | 'primary'
+  | 'secondary'
+  | 'accent'
+  | 'primary-outline'
+  | 'secondary-outline'
+  | 'accent-outline';
+
+type Props = JSX.IntrinsicElements['button'] & {
+  size: 'xs' | 'base' | 'lg';
+  variant: ButtonColorSchemeOptions;
+  shadow?: boolean;
+};
+
+const filledColorScheme = (color: string) =>
+  `bg-${color}-500 text-blue-50 hover:bg-${color}-600 focus:ring-${color}-300 active:bg-${color}-700`;
+const outlinedColorScheme = (color: string) =>
+  `bg-transparent text-${color}-500 border border-${color}-500 hover:text-blue-50 hover:bg-${color}-500 focus:ring-${color}-300 active:bg-${color}-600`;
+
+const colorSchemes: Record<ButtonColorSchemeOptions, string> = {
+  primary: filledColorScheme('green'),
+  'primary-outline': outlinedColorScheme('green'),
+  secondary: filledColorScheme('gray'),
+  'secondary-outline': outlinedColorScheme('gray'),
+  accent: filledColorScheme('orange'),
+  'accent-outline': outlinedColorScheme('orange'),
+};
+
+const Button: FC<Props> = ({ size, variant, shadow, children, ...props }) => {
+  const colorScheme = colorSchemes[variant];
+  const baseStyle =
+    'rounded focus:outline-none focus:ring disabled:opacity-50 disabled:cursor-not-allowed';
+  const styles = classNames(baseStyle, colorScheme, {
+    'shadow-md': shadow,
+    'text-xs py-1 px-4': size === 'xs',
+    'text-base py-2 px-4': size === 'base',
+    'text-xl py-3 px-4': size === 'lg',
+  });
+
+  return (
+    <button className={styles} {...props}>
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/packages/web/components/Button.tsx
+++ b/packages/web/components/Button.tsx
@@ -10,8 +10,8 @@ type ButtonColorSchemeOptions =
   | 'accent-outline';
 
 type Props = JSX.IntrinsicElements['button'] & {
-  size: 'xs' | 'base' | 'lg';
   variant: ButtonColorSchemeOptions;
+  size?: 'xs' | 'base' | 'lg';
   shadow?: boolean;
 };
 
@@ -29,7 +29,13 @@ const colorSchemes: Record<ButtonColorSchemeOptions, string> = {
   'accent-outline': outlinedColorScheme('orange'),
 };
 
-const Button: FC<Props> = ({ size, variant, shadow, children, ...props }) => {
+const Button: FC<Props> = ({
+  size = 'base',
+  variant,
+  shadow,
+  children,
+  ...props
+}) => {
   const colorScheme = colorSchemes[variant];
   const baseStyle =
     'rounded focus:outline-none focus:ring disabled:opacity-50 disabled:cursor-not-allowed';

--- a/packages/web/components/LabeldFormElement.tsx
+++ b/packages/web/components/LabeldFormElement.tsx
@@ -1,0 +1,36 @@
+import { FC } from 'react';
+
+type Props = {
+  label: string;
+  size?: 'xs' | 'base' | 'lg';
+  error?: string;
+  positionErrorMessageAbsolute?: boolean;
+};
+
+const LabeledFormElement: FC<Props> = ({
+  size = 'base',
+  label,
+  error,
+  children,
+  positionErrorMessageAbsolute = true,
+}) => {
+  return (
+    <div>
+      <label className={`text-${size} ${error && 'text-red-600'}`}>
+        <span className="block mb-1.5">{label}</span>
+        {children}
+      </label>
+      {error && (
+        <span
+          className={`text-${size} text-red-600 block ${
+            positionErrorMessageAbsolute && 'absolute'
+          }`}
+        >
+          {error}
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default LabeledFormElement;

--- a/packages/web/components/RadioButton.tsx
+++ b/packages/web/components/RadioButton.tsx
@@ -1,0 +1,39 @@
+import classNames from 'classnames';
+import { forwardRef } from 'react';
+
+type Props = Omit<JSX.IntrinsicElements['input'], 'size'> & {
+  size?: 'xs' | 'base' | 'lg';
+  name: string;
+  label: string;
+  checked: boolean;
+};
+
+const RadioButton = forwardRef<HTMLInputElement, Props>(
+  ({ size = 'base', name, label, checked, ...props }, ref) => {
+    const baseStyle =
+      'px-2 py-1 border border-gray-500 bg-transparent text-gray-500 rounded apearence-none';
+
+    const styles = classNames(baseStyle, {
+      'text-xs': size === 'xs',
+      'text-base': size === 'base',
+      'text-xl': size === 'lg',
+      'bg-transparent text-gray-500': !checked,
+      'text-blue-50 bg-gray-500': checked,
+    });
+
+    return (
+      <label className={styles}>
+        {label}
+        <input
+          type="radio"
+          className="invisible absolute"
+          ref={ref}
+          name={name}
+          {...props}
+        ></input>
+      </label>
+    );
+  }
+);
+
+export default RadioButton;

--- a/packages/web/components/SelectBox.tsx
+++ b/packages/web/components/SelectBox.tsx
@@ -1,24 +1,27 @@
 import classNames from 'classnames';
-import { FC } from 'react';
+import { forwardRef } from 'react';
 
 type Props = Omit<JSX.IntrinsicElements['select'], 'size'> & {
   size: 'xs' | 'base' | 'lg';
+  name: string;
 };
 
-const SelectContainer: FC<Props> = ({ size, children, ...props }) => {
-  const baseStyle =
-    'px-2 py-1 border border-gray-400 rounded focus:outline-none focus:ring-1 focus:ring-green-400';
-  const styles = classNames(baseStyle, {
-    'text-xs': size === 'xs',
-    'text-base': size === 'base',
-    'text-xl': size === 'lg',
-  });
+const SelectContainer = forwardRef<HTMLSelectElement, Props>(
+  ({ size, name, children, ...props }, ref) => {
+    const baseStyle =
+      'px-2 py-1 border border-gray-400 rounded focus:outline-none focus:ring-1 focus:ring-green-400';
+    const styles = classNames(baseStyle, {
+      'text-xs': size === 'xs',
+      'text-base': size === 'base',
+      'text-xl': size === 'lg',
+    });
 
-  return (
-    <select className={styles} {...props}>
-      {children}
-    </select>
-  );
-};
+    return (
+      <select className={styles} ref={ref} name={name} {...props}>
+        {children}
+      </select>
+    );
+  }
+);
 
 export default SelectContainer;

--- a/packages/web/components/SelectBox.tsx
+++ b/packages/web/components/SelectBox.tsx
@@ -2,12 +2,12 @@ import classNames from 'classnames';
 import { forwardRef } from 'react';
 
 type Props = Omit<JSX.IntrinsicElements['select'], 'size'> & {
-  size: 'xs' | 'base' | 'lg';
+  size?: 'xs' | 'base' | 'lg';
   name: string;
 };
 
 const SelectContainer = forwardRef<HTMLSelectElement, Props>(
-  ({ size, name, children, ...props }, ref) => {
+  ({ size = 'base', name, children, ...props }, ref) => {
     const baseStyle =
       'px-2 py-1 border border-gray-400 rounded focus:outline-none focus:ring-1 focus:ring-green-400';
     const styles = classNames(baseStyle, {

--- a/packages/web/components/SelectBox.tsx
+++ b/packages/web/components/SelectBox.tsx
@@ -1,0 +1,24 @@
+import classNames from 'classnames';
+import { FC } from 'react';
+
+type Props = Omit<JSX.IntrinsicElements['select'], 'size'> & {
+  size: 'xs' | 'base' | 'lg';
+};
+
+const SelectContainer: FC<Props> = ({ size, children, ...props }) => {
+  const baseStyle =
+    'px-2 py-1 border border-gray-400 rounded focus:outline-none focus:ring-1 focus:ring-green-400';
+  const styles = classNames(baseStyle, {
+    'text-xs': size === 'xs',
+    'text-base': size === 'base',
+    'text-xl': size === 'lg',
+  });
+
+  return (
+    <select className={styles} {...props}>
+      {children}
+    </select>
+  );
+};
+
+export default SelectContainer;

--- a/packages/web/components/SelectableButton.tsx
+++ b/packages/web/components/SelectableButton.tsx
@@ -3,13 +3,14 @@ import { forwardRef } from 'react';
 
 type Props = Omit<JSX.IntrinsicElements['input'], 'size'> & {
   size?: 'xs' | 'base' | 'lg';
+  type: 'radio' | 'checkbox';
   name: string;
   label: string;
   checked: boolean;
 };
 
-const RadioButton = forwardRef<HTMLInputElement, Props>(
-  ({ size = 'base', name, label, checked, ...props }, ref) => {
+const SelectableButton = forwardRef<HTMLInputElement, Props>(
+  ({ size = 'base', type, name, label, checked, ...props }, ref) => {
     const baseStyle =
       'px-2 py-1 border border-gray-500 bg-transparent text-gray-500 rounded apearence-none';
 
@@ -25,7 +26,7 @@ const RadioButton = forwardRef<HTMLInputElement, Props>(
       <label className={styles}>
         {label}
         <input
-          type="radio"
+          type={type}
           className="invisible absolute"
           ref={ref}
           name={name}
@@ -36,4 +37,4 @@ const RadioButton = forwardRef<HTMLInputElement, Props>(
   }
 );
 
-export default RadioButton;
+export default SelectableButton;

--- a/packages/web/components/TextArea.tsx
+++ b/packages/web/components/TextArea.tsx
@@ -1,0 +1,25 @@
+import classNames from 'classnames';
+import { FC } from 'react';
+
+type Props = JSX.IntrinsicElements['textarea'] & {
+  size: 'xs' | 'base' | 'lg';
+  resize?: 'none' | 'vertical' | 'horizontal' | 'both';
+};
+
+const TextArea: FC<Props> = ({ size, resize = 'both', ...props }) => {
+  const baseStyle =
+    'border leading-relaxed border-gray-400 rounded focus:outline-none focus:ring-1 focus:ring-green-400';
+  const styles = classNames(baseStyle, {
+    'text-xs py-1 px-1': size === 'xs',
+    'text-base py-2 px-2': size === 'base',
+    'text-xl py-3 px-3': size === 'lg',
+    'resize-none': resize === 'both',
+    'resize-y': resize === 'vertical',
+    'resize-x': resize === 'horizontal',
+    resize: resize === 'both',
+  });
+
+  return <textarea className={styles} {...props} />;
+};
+
+export default TextArea;

--- a/packages/web/components/TextArea.tsx
+++ b/packages/web/components/TextArea.tsx
@@ -2,14 +2,17 @@ import classNames from 'classnames';
 import { forwardRef } from 'react';
 
 type Props = JSX.IntrinsicElements['textarea'] & {
-  size: 'xs' | 'base' | 'lg';
+  size?: 'xs' | 'base' | 'lg';
   name: string;
   isError?: boolean;
   resize?: 'none' | 'vertical' | 'horizontal' | 'both';
 };
 
 const TextArea = forwardRef<HTMLTextAreaElement, Props>(
-  ({ size, name, isError = false, resize = 'both', ...props }, ref) => {
+  (
+    { size = 'base', name, isError = false, resize = 'vertical', ...props },
+    ref
+  ) => {
     const baseStyle = 'leading-relaxed rounded focus:outline-none focus:ring-1';
     const borderStyle = isError
       ? 'border-2 border-red-600 focus:ring-red-400'

--- a/packages/web/components/TextArea.tsx
+++ b/packages/web/components/TextArea.tsx
@@ -1,25 +1,28 @@
 import classNames from 'classnames';
-import { FC } from 'react';
+import { forwardRef } from 'react';
 
 type Props = JSX.IntrinsicElements['textarea'] & {
   size: 'xs' | 'base' | 'lg';
+  name: string;
   resize?: 'none' | 'vertical' | 'horizontal' | 'both';
 };
 
-const TextArea: FC<Props> = ({ size, resize = 'both', ...props }) => {
-  const baseStyle =
-    'border leading-relaxed border-gray-400 rounded focus:outline-none focus:ring-1 focus:ring-green-400';
-  const styles = classNames(baseStyle, {
-    'text-xs py-1 px-1': size === 'xs',
-    'text-base py-2 px-2': size === 'base',
-    'text-xl py-3 px-3': size === 'lg',
-    'resize-none': resize === 'both',
-    'resize-y': resize === 'vertical',
-    'resize-x': resize === 'horizontal',
-    resize: resize === 'both',
-  });
+const TextArea = forwardRef<HTMLTextAreaElement, Props>(
+  ({ size, name, resize = 'both', ...props }, ref) => {
+    const baseStyle =
+      'border leading-relaxed border-gray-400 rounded focus:outline-none focus:ring-1 focus:ring-green-400';
+    const styles = classNames(baseStyle, {
+      'text-xs py-1 px-1': size === 'xs',
+      'text-base py-2 px-2': size === 'base',
+      'text-xl py-3 px-3': size === 'lg',
+      'resize-none': resize === 'both',
+      'resize-y': resize === 'vertical',
+      'resize-x': resize === 'horizontal',
+      resize: resize === 'both',
+    });
 
-  return <textarea className={styles} {...props} />;
-};
+    return <textarea className={styles} ref={ref} name={name} {...props} />;
+  }
+);
 
 export default TextArea;

--- a/packages/web/components/TextArea.tsx
+++ b/packages/web/components/TextArea.tsx
@@ -4,14 +4,17 @@ import { forwardRef } from 'react';
 type Props = JSX.IntrinsicElements['textarea'] & {
   size: 'xs' | 'base' | 'lg';
   name: string;
+  isError?: boolean;
   resize?: 'none' | 'vertical' | 'horizontal' | 'both';
 };
 
 const TextArea = forwardRef<HTMLTextAreaElement, Props>(
-  ({ size, name, resize = 'both', ...props }, ref) => {
-    const baseStyle =
-      'border leading-relaxed border-gray-400 rounded focus:outline-none focus:ring-1 focus:ring-green-400';
-    const styles = classNames(baseStyle, {
+  ({ size, name, isError = false, resize = 'both', ...props }, ref) => {
+    const baseStyle = 'leading-relaxed rounded focus:outline-none focus:ring-1';
+    const borderStyle = isError
+      ? 'border-2 border-red-600 focus:ring-red-400'
+      : 'border border-gray-400 focus:ring-green-400';
+    const styles = classNames(baseStyle, borderStyle, {
       'text-xs py-1 px-1': size === 'xs',
       'text-base py-2 px-2': size === 'base',
       'text-xl py-3 px-3': size === 'lg',

--- a/packages/web/components/TextInput.tsx
+++ b/packages/web/components/TextInput.tsx
@@ -5,6 +5,7 @@ type Props = Omit<JSX.IntrinsicElements['input'], 'size'> & {
   size: 'xs' | 'base' | 'lg';
   width: 'xs' | 'base' | 'lg';
   name: string;
+  isError?: boolean;
 };
 
 const sizeSchemes = {
@@ -14,10 +15,12 @@ const sizeSchemes = {
 };
 
 const TextInput = forwardRef<HTMLInputElement, Props>(
-  ({ size, width, name, ...props }, ref) => {
-    const baseStyle =
-      'border border-gray-400 rounded focus:outline-none focus:ring-1 focus:ring-green-400';
-    const styles = classNames(baseStyle, {
+  ({ size, width, name, isError = false, ...props }, ref) => {
+    const baseStyle = 'rounded focus:outline-none focus:ring-1';
+    const borderStyle = isError
+      ? 'border-2 border-red-600 focus:ring-red-400'
+      : 'border border-gray-400 focus:ring-green-400';
+    const styles = classNames(baseStyle, borderStyle, {
       'text-xs py-1 px-5': size === 'xs',
       'text-base py-2 px-5': size === 'base',
       'text-xl py-3 px-5': size === 'lg',

--- a/packages/web/components/TextInput.tsx
+++ b/packages/web/components/TextInput.tsx
@@ -1,9 +1,10 @@
 import classNames from 'classnames';
-import { FC } from 'react';
+import { forwardRef } from 'react';
 
 type Props = Omit<JSX.IntrinsicElements['input'], 'size'> & {
   size: 'xs' | 'base' | 'lg';
   width: 'xs' | 'base' | 'lg';
+  name: string;
 };
 
 const sizeSchemes = {
@@ -12,16 +13,26 @@ const sizeSchemes = {
   lg: 50,
 };
 
-const TextInput: FC<Props> = ({ size, width, ...props }) => {
-  const baseStyle =
-    'border border-gray-400 rounded focus:outline-none focus:ring-1 focus:ring-green-400';
-  const styles = classNames(baseStyle, {
-    'text-xs py-1 px-5': size === 'xs',
-    'text-base py-2 px-5': size === 'base',
-    'text-xl py-3 px-5': size === 'lg',
-  });
+const TextInput = forwardRef<HTMLInputElement, Props>(
+  ({ size, width, name, ...props }, ref) => {
+    const baseStyle =
+      'border border-gray-400 rounded focus:outline-none focus:ring-1 focus:ring-green-400';
+    const styles = classNames(baseStyle, {
+      'text-xs py-1 px-5': size === 'xs',
+      'text-base py-2 px-5': size === 'base',
+      'text-xl py-3 px-5': size === 'lg',
+    });
 
-  return <input className={styles} size={sizeSchemes[width]} {...props} />;
-};
+    return (
+      <input
+        className={styles}
+        size={sizeSchemes[width]}
+        ref={ref}
+        name={name}
+        {...props}
+      />
+    );
+  }
+);
 
 export default TextInput;

--- a/packages/web/components/TextInput.tsx
+++ b/packages/web/components/TextInput.tsx
@@ -1,0 +1,27 @@
+import classNames from 'classnames';
+import { FC } from 'react';
+
+type Props = Omit<JSX.IntrinsicElements['input'], 'size'> & {
+  size: 'xs' | 'base' | 'lg';
+  width: 'xs' | 'base' | 'lg';
+};
+
+const sizeSchemes = {
+  xs: 20,
+  base: 30,
+  lg: 50,
+};
+
+const TextInput: FC<Props> = ({ size, width, ...props }) => {
+  const baseStyle =
+    'border border-gray-400 rounded focus:outline-none focus:ring-1 focus:ring-green-400';
+  const styles = classNames(baseStyle, {
+    'text-xs py-1 px-5': size === 'xs',
+    'text-base py-2 px-5': size === 'base',
+    'text-xl py-3 px-5': size === 'lg',
+  });
+
+  return <input className={styles} size={sizeSchemes[width]} {...props} />;
+};
+
+export default TextInput;

--- a/packages/web/components/TextInput.tsx
+++ b/packages/web/components/TextInput.tsx
@@ -2,8 +2,8 @@ import classNames from 'classnames';
 import { forwardRef } from 'react';
 
 type Props = Omit<JSX.IntrinsicElements['input'], 'size'> & {
-  size: 'xs' | 'base' | 'lg';
-  width: 'xs' | 'base' | 'lg';
+  size?: 'xs' | 'base' | 'lg';
+  width?: 'xs' | 'base' | 'lg';
   name: string;
   isError?: boolean;
 };
@@ -15,7 +15,7 @@ const sizeSchemes = {
 };
 
 const TextInput = forwardRef<HTMLInputElement, Props>(
-  ({ size, width, name, isError = false, ...props }, ref) => {
+  ({ size = 'base', width = 'base', name, isError = false, ...props }, ref) => {
     const baseStyle = 'rounded focus:outline-none focus:ring-1';
     const borderStyle = isError
       ? 'border-2 border-red-600 focus:ring-red-400'

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@hookform/resolvers": "^1.3.7",
     "@what-is-grass/shared": "^1.0.0",
+    "classnames": "^2.3.1",
     "next": "latest",
     "next-transpile-modules": "^7.2.0",
     "react": "16.13.1",

--- a/packages/web/pages/new-answer/[id].tsx
+++ b/packages/web/pages/new-answer/[id].tsx
@@ -8,7 +8,7 @@ import Button from '../../components/Button';
 import LabeledFormElement from '../../components/LabeldFormElement';
 import Layout from '../../components/Layout';
 import PrivatePage from '../../components/PrivatePage';
-import RadioButton from '../../components/RadioButton';
+import SelectableButton from '../../components/SelectableButton';
 import TextArea from '../../components/TextArea';
 
 const index = 'クラッシュバンディグー';
@@ -174,8 +174,9 @@ const NewAnswerPage: React.FC = () => {
             >
               <div className="flex flex-wrap gap-x-2 gap-y-2">
                 {categories.map((category) => (
-                  <RadioButton
+                  <SelectableButton
                     key={category.id}
+                    type="radio"
                     name="category"
                     ref={register}
                     value={category.id}

--- a/packages/web/pages/new-answer/[id].tsx
+++ b/packages/web/pages/new-answer/[id].tsx
@@ -179,7 +179,7 @@ const NewAnswerPage: React.FC = () => {
                     type="radio"
                     name="category"
                     ref={register}
-                    value={category.id}
+                    defaultValue={category.id}
                     label={category.category_tag_name}
                     checked={selectedCategory === category.id}
                   />

--- a/packages/web/pages/new-answer/[id].tsx
+++ b/packages/web/pages/new-answer/[id].tsx
@@ -4,21 +4,42 @@ import { useRouter } from 'next/router';
 import React from 'react';
 import { SubmitHandler, useFieldArray, useForm } from 'react-hook-form';
 import * as yup from 'yup';
+import Button from '../../components/Button';
+import LabeledFormElement from '../../components/LabeldFormElement';
 import Layout from '../../components/Layout';
 import PrivatePage from '../../components/PrivatePage';
+import RadioButton from '../../components/RadioButton';
+import TextArea from '../../components/TextArea';
+
+const index = 'クラッシュバンディグー';
+const categories = [
+  { id: 1, category_tag_name: 'slang' },
+  { id: 2, category_tag_name: 'formal' },
+  { id: 3, category_tag_name: 'polite' },
+  { id: 4, category_tag_name: 'casual' },
+  { id: 5, category_tag_name: 'offensive' },
+  { id: 6, category_tag_name: 'intelligent' },
+  { id: 7, category_tag_name: 'writtern language' },
+  { id: 8, category_tag_name: 'spoken language' },
+  { id: 9, category_tag_name: 'poetic' },
+  { id: 10, category_tag_name: 'proverb' },
+  { id: 11, category_tag_name: 'obsolete' },
+];
 
 type FormValues = {
   definition: string;
   example: { sentence: string }[];
   origin: string;
   note: string;
+  category: number;
 };
 
 const newAnswerFormSchema = yup.object({
-  definition: yup.string().required(),
+  definition: yup.string().required('ここは必須項目だよん'),
   example: yup.array(yup.object({ sentence: yup.string() })),
   origin: yup.string(),
   note: yup.string(),
+  category: yup.number().nullable().required('選んでね'),
 });
 
 const NewAnswerPage: React.FC = () => {
@@ -56,6 +77,8 @@ const NewAnswerPage: React.FC = () => {
   const disableAppend =
     watch('example').filter((e) => e.sentence === '').length !== 0;
 
+  const selectedCategory = +watch('category');
+
   const onSubmit: SubmitHandler<FormValues> = (data) => {
     const example = data.example.filter((e) => e.sentence !== '');
     const newAnswer = {
@@ -69,52 +92,106 @@ const NewAnswerPage: React.FC = () => {
   return (
     <PrivatePage redirectTo="/">
       <Layout title="New Answer">
-        <h1>回答してあげよう</h1>
-        <form onSubmit={handleSubmit(onSubmit)}>
-          <label>
-            意味:
-            <textarea name="definition" ref={register({ required: true })} />
-            {errors.definition && <span>意味だけは答えてちょうだいな</span>}
-          </label>
-          <br />
-          <label>
-            由来: <textarea name="origin" ref={register()} />
-          </label>
-          <br />
-          {fields.map((example, index) => (
-            <label key={example.id}>
-              {`例文${index}: `}
-              <input
-                type="text"
-                name={`example[${index}].sentence`}
-                ref={register()}
-                defaultValue={example.sentence}
+        <h1 className="text-2xl p-3">
+          <span className="text-3xl text-green-700">{index}</span>
+          について回答する
+        </h1>
+        <form className="flex justify-center" onSubmit={handleSubmit(onSubmit)}>
+          <div className="flex-initial flex-col item-start space-y-10 w-9/12 bg-white border rounded border-gray-300 p-3">
+            <LabeledFormElement
+              label="言葉の意味"
+              error={errors.definition?.message}
+            >
+              <TextArea
+                name="definition"
+                ref={register}
+                isError={errors.definition !== void 0}
+                rows={8}
+                cols={70}
               />
-              <button
-                type="button"
-                onClick={() => onRemoveExample(index)}
-                disabled={disableRemove}
-              >
-                この例文を削除
-              </button>
-              {errors.example?.[index]?.sentence?.message}
-              <br />
-            </label>
-          ))}
-          <button
-            type="button"
-            onClick={() => onAppendExample({})}
-            disabled={disableAppend}
-          >
-            もっと例文を追加
-          </button>
-          <br />
-          <label>
-            備考: <textarea name="note" ref={register()} />
-          </label>
-          <br />
-          <input type="submit" disabled={isLoading} />
-          {isLoading ? '送信中...' : null}
+            </LabeledFormElement>
+            <LabeledFormElement
+              label="言葉の由来"
+              error={errors.origin?.message}
+            >
+              <TextArea
+                name="origin"
+                ref={register}
+                isError={errors.origin !== void 0}
+                rows={8}
+                cols={70}
+              />
+            </LabeledFormElement>
+            {fields.map((example, index) => (
+              <div key={example.id}>
+                <LabeledFormElement
+                  label={`${index + 1}つ目の例文`}
+                  error={errors.example?.[index]?.sentence?.message}
+                >
+                  <div className="flex space-x-2 items-end">
+                    <TextArea
+                      name={`example[${index}].sentence`}
+                      ref={register()}
+                      isError={errors.example?.[index] !== void 0}
+                      rows={2}
+                      cols={50}
+                    />
+                    <Button
+                      variant="secondary"
+                      type="button"
+                      onClick={() => onRemoveExample(index)}
+                      disabled={disableRemove}
+                    >
+                      この例文を削除
+                    </Button>
+                  </div>
+                </LabeledFormElement>
+              </div>
+            ))}
+            <Button
+              variant="secondary"
+              type="button"
+              onClick={() => onAppendExample({})}
+              disabled={disableAppend}
+            >
+              もっと例文を追加
+            </Button>
+            <LabeledFormElement
+              label="言葉についてのメモ"
+              error={errors.note?.message}
+            >
+              <TextArea
+                name="note"
+                ref={register}
+                isError={errors.note !== void 0}
+                rows={2}
+                cols={50}
+              />
+            </LabeledFormElement>
+            <LabeledFormElement
+              label="この言葉が一番当てはまる部類"
+              error={errors.category?.message}
+            >
+              <div className="flex flex-wrap gap-x-2 gap-y-2">
+                {categories.map((category) => (
+                  <RadioButton
+                    key={category.id}
+                    name="category"
+                    ref={register}
+                    value={category.id}
+                    label={category.category_tag_name}
+                    checked={selectedCategory === category.id}
+                  />
+                ))}
+              </div>
+            </LabeledFormElement>
+            <div className="flex justify-center">
+              <Button variant="primary" type="submit" disabled={isLoading}>
+                回答
+              </Button>
+              {isLoading ? '送信中...' : null}
+            </div>
+          </div>
         </form>
       </Layout>
     </PrivatePage>

--- a/packages/web/tailwind.config.js
+++ b/packages/web/tailwind.config.js
@@ -1,11 +1,22 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const colors = require('tailwindcss/colors');
+
 module.exports = {
   purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
   darkMode: false, // or 'media' or 'class'
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        orange: colors.orange,
+      },
+    },
   },
   variants: {
-    extend: {},
+    extend: {
+      backgroundColor: ['active'],
+      opacity: ['disabled'],
+      cursor: ['disabled'],
+    },
   },
   plugins: [],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3690,6 +3690,11 @@ classnames@2.2.6:
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
+classnames@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
+  integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
+
 clean-css@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.3.tgz#507b5de7d97b48ee53d84adb0160ff6216380f78"


### PR DESCRIPTION
##概要
テキストボックス、テキストエリア、チェックボックス、ラジオボタン、ボタンのスタイル付きのコンポーネントを雑に作った。
## 備考
propsに渡せるものをアプリ内でのユースケースに合わせて制限したかったけど、要件を洗い出してる時間がないのでHTMLElementが受け取れるもの全てを受け取って流し込んでる。