### PR TITLE
Feature/display category tag

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -13,6 +13,8 @@ export {
   useLazyGetIndicesQuery,
   useGetUserIndicesQuery,
   useGetFavoriteIndicesQuery,
+  useGetIndexQuery,
+  useLazyGetIndexQuery,
   useAddFavoriteIndexMutation,
   useRemoveFavoriteIndexMutation,
   useAddIndexMutation,

--- a/packages/shared/src/mocks/handlers.ts
+++ b/packages/shared/src/mocks/handlers.ts
@@ -1,13 +1,13 @@
 import { rest } from 'msw';
 import { getAnswer, newAnswer } from './resolvers/answer';
 import {
+  deleteFavoriteIndex,
+  getFavoriteIndices,
+  getIndex,
   getQuestions,
   getUserQuestions,
-  newQuestion,
-  getFavoriteIndices,
   newFavoriteIndex,
-  getIndex,
-  deleteFavoriteIndex,
+  newQuestion,
 } from './resolvers/question';
 import {
   editUser,

--- a/packages/shared/src/mocks/handlers.ts
+++ b/packages/shared/src/mocks/handlers.ts
@@ -6,6 +6,7 @@ import {
   newQuestion,
   getFavoriteIndices,
   newFavoriteIndex,
+  getIndex,
   deleteFavoriteIndex,
 } from './resolvers/question';
 import {
@@ -22,6 +23,7 @@ export const handlers = [
   rest.get('/question', getQuestions),
   rest.get('/user/question-list', getUserQuestions),
   rest.get('/favorite-question', getFavoriteIndices),
+  rest.get('/spesific-question', getIndex),
   rest.get('/answer', getAnswer),
   rest.get('/whoami', getLoginUser),
   rest.post('/question', newQuestion),

--- a/packages/shared/src/mocks/handlers.ts
+++ b/packages/shared/src/mocks/handlers.ts
@@ -23,7 +23,7 @@ export const handlers = [
   rest.get('/question', getQuestions),
   rest.get('/user/question-list', getUserQuestions),
   rest.get('/favorite-question', getFavoriteIndices),
-  rest.get('/spesific-question', getIndex),
+  rest.get('/specific-question', getIndex),
   rest.get('/answer', getAnswer),
   rest.get('/whoami', getLoginUser),
   rest.post('/question', newQuestion),

--- a/packages/shared/src/mocks/resolvers/question.ts
+++ b/packages/shared/src/mocks/resolvers/question.ts
@@ -167,7 +167,7 @@ export const newFavoriteIndex: Resolver = (_, res, ctx) => {
         frequently_used_count: 10,
         answer_count: 1,
         best_answer: 'いいところですよ',
-        category_tags: [{ id: 1, cateogry_tag_name: 'slang' }],
+        category_tags: [{ id: 1, category_tag_name: 'slang' }],
         date: '2021-06-21',
       },
     })
@@ -190,7 +190,7 @@ export const getFavoriteIndices: Resolver = (_, res, ctx) => {
           frequently_used_count: 10,
           answer_count: 1,
           best_answer: 'いいところですよ',
-          category_tags: [{ id: 1, cateogry_tag_name: 'slang' }],
+          category_tags: [{ id: 1, category_tag_name: 'slang' }],
           date: '2021-06-21',
         },
       ],
@@ -209,7 +209,7 @@ export const getIndex: Resolver = (_, res, ctx) => {
         frequently_used_count: 1,
         answer_count: 3,
         best_answer: 'おもしろぃ',
-        category_tags: [{ id: 1, cateogry_tag_name: 'slang' }],
+        category_tags: [{ id: 1, category_tag_name: 'slang' }],
         date: '2021-06-21',
       },
     })

--- a/packages/shared/src/mocks/resolvers/question.ts
+++ b/packages/shared/src/mocks/resolvers/question.ts
@@ -197,3 +197,23 @@ export const getFavoriteIndices: Resolver = (_, res, ctx) => {
     })
   );
 };
+
+export const getIndex: Resolver = (_, res, ctx) => {
+  return res(
+    ctx.status(200),
+    ctx.json({
+      indices: [
+        {
+          index_id: 100,
+          index: '草',
+          questioner: '1',
+          frequently_used_count: 1,
+          answer_count: 3,
+          best_answer: 'おもしろぃ',
+          category_tags: [{ id: 1, cateogry_tag_name: 'slang' }],
+          date: '2021-06-21',
+        },
+      ],
+    })
+  );
+};

--- a/packages/shared/src/mocks/resolvers/question.ts
+++ b/packages/shared/src/mocks/resolvers/question.ts
@@ -4,10 +4,17 @@ export const newQuestion: Resolver = (_, res, ctx) => {
   return res(
     ctx.status(201),
     ctx.json({
-      id: 2,
-      index: 'くさ',
-      language_id: 1,
-      date: '2021-06-22T12:00:00.000+09:00',
+      index: {
+        id: 2,
+        index: 'くさ',
+        questioner: 'ATG',
+        frequently_used_count: 0,
+        answer_count: 0,
+        language_id: 1,
+        best_answer: null,
+        category_tags: [],
+        date: '2021-06-22T12:00:00.000+09:00',
+      },
     })
   );
 };
@@ -24,6 +31,16 @@ export const getQuestions: Resolver = (_, res, ctx) => {
           frequently_used_count: 10,
           answer_count: 1,
           best_answer: 'いいところですよ',
+          category_tags: [
+            {
+              id: 1,
+              category_tag_name: 'slang',
+            },
+            {
+              id: 2,
+              category_tag_name: 'casual',
+            },
+          ],
           date: '2021-06-21',
         },
         {
@@ -33,6 +50,16 @@ export const getQuestions: Resolver = (_, res, ctx) => {
           frequently_used_count: 100,
           answer_count: 1,
           best_answer: '学校です',
+          category_tags: [
+            {
+              id: 3,
+              category_tag_name: 'formal',
+            },
+            {
+              id: 4,
+              category_tag_name: 'polite',
+            },
+          ],
           date: '2021-06-23',
         },
         {
@@ -42,16 +69,17 @@ export const getQuestions: Resolver = (_, res, ctx) => {
           frequently_used_count: 1000,
           answer_count: 1,
           best_answer: '美味しそうだ',
+          category_tags: [
+            {
+              id: 1,
+              category_tag_name: 'slang',
+            },
+            {
+              id: 2,
+              category_tag_name: 'casual',
+            },
+          ],
           date: '2021-06-25',
-        },
-        {
-          index_id: 104,
-          index: '何を質問したらいいかなぁ？',
-          questioner: '004',
-          frequently_used_count: 10000,
-          answer_count: 1,
-          best_answer: 'こんな簡単な事も聞くなん？お前バカっか？',
-          date: '2021-06-26',
         },
       ],
     })
@@ -71,6 +99,16 @@ export const getUserQuestions: Resolver = (_, res, ctx) => {
           answer_count: 1,
           language_id: 2,
           best_answer: 'すみません。分かりませんでした。',
+          category_tags: [
+            {
+              id: 1,
+              category_tag_name: 'slang',
+            },
+            {
+              id: 2,
+              category_tag_name: 'casual',
+            },
+          ],
           date: '2021-07-11',
         },
         {
@@ -81,6 +119,16 @@ export const getUserQuestions: Resolver = (_, res, ctx) => {
           answer_count: 5,
           language_id: 2,
           best_answer: 'そんなことより進捗どうですか',
+          category_tags: [
+            {
+              id: 1,
+              category_tag_name: 'slang',
+            },
+            {
+              id: 2,
+              category_tag_name: 'casual',
+            },
+          ],
           date: '2021-07-13',
         },
         {
@@ -91,6 +139,16 @@ export const getUserQuestions: Resolver = (_, res, ctx) => {
           answer_count: 1,
           language_id: 1,
           best_answer: "it's the begining of the nightmare",
+          category_tags: [
+            {
+              id: 1,
+              category_tag_name: 'slang',
+            },
+            {
+              id: 5,
+              category_tag_name: 'technical term',
+            },
+          ],
           date: '2021-07-14',
         },
       ],

--- a/packages/shared/src/mocks/resolvers/question.ts
+++ b/packages/shared/src/mocks/resolvers/question.ts
@@ -202,18 +202,16 @@ export const getIndex: Resolver = (_, res, ctx) => {
   return res(
     ctx.status(200),
     ctx.json({
-      indices: [
-        {
-          index_id: 100,
-          index: '草',
-          questioner: '1',
-          frequently_used_count: 1,
-          answer_count: 3,
-          best_answer: 'おもしろぃ',
-          category_tags: [{ id: 1, cateogry_tag_name: 'slang' }],
-          date: '2021-06-21',
-        },
-      ],
+      index: {
+        index_id: 100,
+        index: '草',
+        questioner: '1',
+        frequently_used_count: 1,
+        answer_count: 3,
+        best_answer: 'おもしろぃ',
+        category_tags: [{ id: 1, cateogry_tag_name: 'slang' }],
+        date: '2021-06-21',
+      },
     })
   );
 };

--- a/packages/shared/src/redux/services/word.ts
+++ b/packages/shared/src/redux/services/word.ts
@@ -23,6 +23,8 @@ import {
   GetFavoriteIndicesResponse,
   GetIndicesRequest,
   GetIndicesResponse,
+  GetIndexRequest,
+  GetIndexResponse,
   GetUserIndicesRequest,
   GetUserIndicesResponse,
   Index,
@@ -77,6 +79,13 @@ export const wordApi = createApi({
         params,
       }),
       transformResponse: (res: GetFavoriteIndicesResponse) => res.indices,
+    }),
+    getIndex: builder.query<Index, GetIndexRequest>({
+      query: (params) => ({
+        url: '/specific-question',
+        params,
+      }),
+      transformResponse: (res: GetIndexResponse) => res.index,
     }),
     addIndex: builder.mutation<NewIndexResponse, NewIndexRequest>({
       query: (body) => ({
@@ -149,6 +158,8 @@ export const useLazyGetIndicesQuery = wordApi.endpoints.getIndices.useLazyQuery;
 export const useGetUserIndicesQuery = wordApi.endpoints.getUserIndices.useQuery;
 export const useGetFavoriteIndicesQuery =
   wordApi.endpoints.getFavoriteIndices.useQuery;
+export const useGetIndexQuery = wordApi.endpoints.getIndex.useQuery;
+export const useLazyGetIndexQuery = wordApi.endpoints.getIndex.useLazyQuery;
 export const useAddIndexMutation = wordApi.endpoints.addIndex.useMutation;
 export const useAddFavoriteIndexMutation =
   wordApi.endpoints.addFavoriteIndex.useMutation;

--- a/packages/shared/src/types/answer.ts
+++ b/packages/shared/src/types/answer.ts
@@ -15,6 +15,7 @@ export type NewAnswerRequest = {
   definition: Answer['definition'];
   origin?: Answer['origin'];
   note?: Answer['note'];
+  category_tag_id: number;
   example?: Example['example_sentence'][];
 };
 export type NewAnswerResponse = Answer;

--- a/packages/shared/src/types/indexType.ts
+++ b/packages/shared/src/types/indexType.ts
@@ -5,8 +5,14 @@ export type Index = {
   frequently_used_count: number;
   answer_count: number;
   language_id: number;
+  category_tags: Category[];
   best_answer: string;
   date: string;
+};
+
+type Category = {
+  id: number;
+  category_tag_name: string;
 };
 
 export type NewIndexResponse = Omit<Index, 'best_answer'>;

--- a/packages/shared/src/types/indexType.ts
+++ b/packages/shared/src/types/indexType.ts
@@ -37,6 +37,9 @@ export type GetFavoriteIndicesRequest = Partial<
 >;
 export type GetFavoriteIndicesResponse = GetIndicesResponse;
 
+export type GetIndexRequest = { index_id: Index['id'] };
+export type GetIndexResponse = { index: Index };
+
 export type NewFavoriteIndicesRequest = { index_id: Index['id'] };
 export type NewFavoriteIndicesResponse = { index: Index };
 

--- a/packages/web/components/IndexItem.tsx
+++ b/packages/web/components/IndexItem.tsx
@@ -2,6 +2,7 @@ import { Index } from '@what-is-grass/shared';
 import Link from 'next/link';
 import { FC, useState } from 'react';
 import Button from '../components/Button';
+import Tag from '../components/Tag';
 
 type Props = {
   question: Index;
@@ -16,6 +17,11 @@ const IndexItem: FC<Props> = ({ question }) => {
     <Link href={`/answers/${question.id}`}>
       <div className="rounded py-4 px-6 border border-gray-300 shadow-md hover:cursor-pointer">
         <p className="text-3xl text-green-600 mb-2">{question.index}</p>
+        <div className="flex space-x-2">
+          {question.category_tags.map(({ id, category_tag_name }) => {
+            return <Tag key={id} tagName={category_tag_name} />;
+          })}
+        </div>
         <p className="text-lg my-2 mx-2">{question.best_answer}</p>
         <div className="relative whitespace-nowrap">
           <span>{frequentlyUsedCount}人がよく使ってる</span>

--- a/packages/web/components/Tag.tsx
+++ b/packages/web/components/Tag.tsx
@@ -1,0 +1,13 @@
+import { FC } from 'react';
+
+type Props = {
+  tagName: string;
+};
+
+const Tag: FC<Props> = ({ tagName }) => {
+  return (
+    <span className="text-sm py-0.5 px-1 rounded bg-gray-300">{tagName}</span>
+  );
+};
+
+export default Tag;

--- a/packages/web/pages/answers/[id].tsx
+++ b/packages/web/pages/answers/[id].tsx
@@ -1,5 +1,6 @@
 import {
   useAddFavoriteIndexMutation,
+  useLazyGetIndexQuery,
   useLazyGetAnswersQuery,
   useSelector,
 } from '@what-is-grass/shared';
@@ -9,10 +10,14 @@ import { useEffect, useState } from 'react';
 import AnswerItem from '../../components/AnswerItem';
 import Button from '../../components/Button';
 import Layout from '../../components/Layout';
+import Tag from '../../components/Tag';
 
 const AnswersPage: React.FC = () => {
-  const [triggerGetAnswersQuery, { data, isLoading }] =
-    useLazyGetAnswersQuery();
+  const [
+    triggerGetAnswersQuery,
+    { data: answers, isLoading: isAnswerLoading },
+  ] = useLazyGetAnswersQuery();
+  const [triggerGetIndexQuery, { data: index }] = useLazyGetIndexQuery();
   const [addToFavorite] = useAddFavoriteIndexMutation();
   const [favorited, setFavorited] = useState(false);
   const user = useSelector((state) => state.auth.user);
@@ -23,8 +28,9 @@ const AnswersPage: React.FC = () => {
   useEffect(() => {
     if (indexId) {
       triggerGetAnswersQuery({ index_id: +indexId });
+      triggerGetIndexQuery({ index_id: +indexId });
     }
-  }, [indexId, triggerGetAnswersQuery]);
+  }, [indexId, triggerGetAnswersQuery, triggerGetIndexQuery]);
 
   const handleNewAnswerClick = () => {
     routerPush(`/new-answer/${indexId}`);
@@ -41,7 +47,7 @@ const AnswersPage: React.FC = () => {
     }
 
     return (
-      <div className="m-4 flex justify-end">
+      <div className="mb-4 flex justify-end">
         {user ? (
           <div className="flex space-x-2">
             <Button
@@ -73,31 +79,43 @@ const AnswersPage: React.FC = () => {
 
   return (
     <Layout>
-      {makeNewAnswerButton()}
-      <div className="flex justify-center mb-6">
-        <div className="grid grid-cols-5 gap-6 w-9/12">
-          {isLoading ? 'ロード中...' : null}
-          <div className="flex flex-col gap-4 col-span-3">
-            {data &&
-              data.map((answer, index) => (
-                <AnswerItem
-                  key={answer.id}
-                  answer={answer}
-                  featured={index === 0}
-                />
-              ))}
+      <div className="m-4">
+        {index && (
+          <div className="mb-2 ml-16">
+            <h1 className="mb-2 text-3xl">{index.index}</h1>
+            <div className="mb-2 flex space-x-2">
+              {index.category_tags.map(({ id, category_tag_name }) => {
+                return <Tag key={id} tagName={category_tag_name} />;
+              })}
+            </div>
           </div>
-          <div className="flex flex-col gap-4 col-span-2 rounded py-4 px-6 border border-gray-300">
-            <span>例文</span>
-            {[
-              '私は私の前で泣かないでください',
-              '私は私の前で泣かないでください',
-              '私は私の前で泣かないでください',
-              '私は私の前で泣かないでください',
-              '私は私の前で泣かないでください',
-            ].map((e, index) => (
-              <p key={index}>{e}</p>
-            ))}
+        )}
+        {makeNewAnswerButton()}
+        <div className="flex justify-center mb-6">
+          <div className="grid grid-cols-5 gap-6 w-9/12">
+            {isAnswerLoading ? 'ロード中...' : null}
+            <div className="flex flex-col gap-4 col-span-3">
+              {answers &&
+                answers.map((answer, index) => (
+                  <AnswerItem
+                    key={answer.id}
+                    answer={answer}
+                    featured={index === 0}
+                  />
+                ))}
+            </div>
+            <div className="flex flex-col gap-4 col-span-2 rounded py-4 px-6 border border-gray-300">
+              <span>例文</span>
+              {[
+                '私は私の前で泣かないでください',
+                '私は私の前で泣かないでください',
+                '私は私の前で泣かないでください',
+                '私は私の前で泣かないでください',
+                '私は私の前で泣かないでください',
+              ].map((e, index) => (
+                <p key={index}>{e}</p>
+              ))}
+            </div>
           </div>
         </div>
       </div>

--- a/packages/web/pages/new-answer/[id].tsx
+++ b/packages/web/pages/new-answer/[id].tsx
@@ -18,7 +18,7 @@ type FormValues = {
   example: { sentence: string }[];
   origin: string;
   note: string;
-  category: number;
+  categoryId: number;
 };
 
 const newAnswerFormSchema = yup.object({
@@ -26,7 +26,7 @@ const newAnswerFormSchema = yup.object({
   example: yup.array(yup.object({ sentence: yup.string() })),
   origin: yup.string(),
   note: yup.string(),
-  category: yup.number().nullable().required('選んでね'),
+  categoryId: yup.number().nullable().required('選んでね'),
 });
 
 const NewAnswerPage: React.FC = () => {
@@ -64,12 +64,13 @@ const NewAnswerPage: React.FC = () => {
   const disableAppend =
     watch('example').filter((e) => e.sentence === '').length !== 0;
 
-  const selectedCategory = +watch('category');
+  const selectedCategory = +watch('categoryId');
 
-  const onSubmit: SubmitHandler<FormValues> = (data) => {
+  const onSubmit: SubmitHandler<FormValues> = ({ categoryId, ...data }) => {
     const example = data.example.filter((e) => e.sentence !== '');
     const newAnswer = {
       index_id: +id,
+      category_tag_id: categoryId,
       ...data,
       example: example.map((e) => e.sentence),
     };
@@ -157,14 +158,14 @@ const NewAnswerPage: React.FC = () => {
             </LabeledFormElement>
             <LabeledFormElement
               label="この言葉が一番当てはまる部類"
-              error={errors.category?.message}
+              error={errors.categoryId?.message}
             >
               <div className="flex flex-wrap gap-x-2 gap-y-2">
                 {categories.map((category) => (
                   <SelectableButton
                     key={category.id}
                     type="radio"
-                    name="category"
+                    name="categoryId"
                     ref={register}
                     defaultValue={category.id}
                     label={category.category_tag_name}


### PR DESCRIPTION
## 概要
見出しにカテゴリタグを表示した

## やったこと
- 検索、質問済み閲覧画面で見出しの下にカテゴリタグを追加した
- 回答一覧画面に見出しを表示して、その下にカテゴリタグを追加した
- 見出し取得APIのエンドポイントを追加した

## 備考
回答一覧画面にはそもそも見出しが表示されてなかった。回答一覧画面は検索画面から遷移してくることが多いと思うのでキャッシュに入ってる見出しデータを再利用したかったけど、url直打ちでくる人もいるからキャッシュに頼り切ることもできず、将来的には「キャッシュににあったらそれを、なかったら新しくリクエスト」とかするかも知れないけど、一旦回答一覧画面をロードした時に見出し取得APIを叩くようにした。