### PR TITLE
Add クッキーで認証時にCSRFトークンを使う

### DIFF
--- a/packages/shared/src/redux/services/word.ts
+++ b/packages/shared/src/redux/services/word.ts
@@ -41,7 +41,11 @@ const fetchFn: (
   input: RequestInfo,
   init?: RequestInit | undefined
 ) => Promise<Response> = async (input, init) => {
-  return await fetch(input, init);
+  const baseInitOptions = { credentials: 'include' as const };
+  const mergedInitOptions = init
+    ? Object.assign(init, baseInitOptions)
+    : baseInitOptions;
+  return await fetch(input, mergedInitOptions);
 };
 
 export const wordApi = createApi({

--- a/packages/shared/src/redux/services/word.ts
+++ b/packages/shared/src/redux/services/word.ts
@@ -53,12 +53,16 @@ export const wordApi = createApi({
   baseQuery: fetchBaseQuery({
     baseUrl: '/',
     fetchFn: fetchFn,
-    prepareHeaders: (headers, { getState }) => {
-      const user = (getState() as any).auth.user;
+    prepareHeaders: (headers) => {
+      const csrfTokenCookie = document.cookie
+        .split('; ')
+        .find((row) => row.startsWith('csrf_access_token'));
 
-      if (user) {
-        headers.set('Authorization', 'Bearer ' + user.access_token);
+      if (csrfTokenCookie) {
+        const csrfToken = csrfTokenCookie.split('=')[1];
+        headers.set('X-CSRF-TOKEN', csrfToken);
       }
+
       return headers;
     },
   }),


### PR DESCRIPTION
## 概要
クッキーを使って認証できるようにした。

## やったこと
- クロスオリジン的な理由でクッキーがついてなかったので修正した
- バックエンドで[2段階クッキーでcsrf対策](https://flask-jwt-extended.readthedocs.io/en/stable/token_locations/#cookies)してる見たいなので対応した